### PR TITLE
Fix video capturer frames format

### DIFF
--- a/examples/src/bin/custom_video_capturer.rs
+++ b/examples/src/bin/custom_video_capturer.rs
@@ -45,25 +45,22 @@ fn main() {
             let render_thread_running_ = render_thread_running.clone();
             std::thread::spawn(move || {
                 let settings = VideoCapturerSettings::default();
-                let capturer = capturer::Capturer::new(settings.format).unwrap();
+                let capturer = capturer::Capturer::new(&settings).unwrap();
                 let mut buf: Vec<u8> = vec![];
-                let expected_len = (settings.width * settings.height * 4) as usize;
                 loop {
                     if !render_thread_running_.load(Ordering::Relaxed) {
                         break;
                     }
                     if let Ok(buffer) = capturer.pull_buffer() {
                         buf.extend_from_slice((*buffer).as_ref());
-                        if buf.len() == expected_len {
-                            let frame = VideoFrame::new(
-                                settings.format,
-                                settings.width,
-                                settings.height,
-                                buf.clone(),
-                            );
-                            video_capturer.provide_frame(0, &frame).unwrap();
-                            buf.clear();
-                        }
+                        let frame = VideoFrame::new(
+                            settings.format,
+                            settings.width,
+                            settings.height,
+                            buf.clone(),
+                        );
+                        video_capturer.provide_frame(0, &frame).unwrap();
+                        buf.clear();
                     }
                     std::thread::sleep(std::time::Duration::from_micros(30 * 1_000));
                 }

--- a/examples/src/capturer.rs
+++ b/examples/src/capturer.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use byte_slice_cast::*;
 use gst::prelude::*;
-use opentok::video_frame::FrameFormat;
+use opentok::video_capturer::VideoCapturerSettings;
 
 #[path = "./common.rs"]
 mod common;
@@ -22,11 +22,19 @@ pub struct Capturer {
 }
 
 impl Capturer {
-    pub fn new(format: FrameFormat) -> Result<Self, Error> {
+    pub fn new(settings: &VideoCapturerSettings) -> Result<Self, Error> {
         gst::init()?;
 
-        let format = gst_from_otc_format(format);
-        let caps = gst::Caps::new_simple("video/x-raw", &[("format", &format.to_string())]);
+        let format = gst_from_otc_format(settings.format);
+        let caps = gst::Caps::new_simple(
+            "video/x-raw",
+            &[
+                ("format", &format.to_string()),
+                ("width", &settings.width),
+                ("height", &settings.height),
+                ("framerate", &gst::Fraction::new(settings.fps, 1)),
+            ],
+        );
 
         let pipeline = gst::Pipeline::new(None);
         let src = gst::ElementFactory::make("videotestsrc", None)

--- a/opentok/src/video_capturer.rs
+++ b/opentok/src/video_capturer.rs
@@ -32,7 +32,7 @@ pub struct VideoCapturerSettings {
 impl Default for VideoCapturerSettings {
     fn default() -> Self {
         Self {
-            format: FrameFormat::Rgba32,
+            format: FrameFormat::Yuv420P,
             width: 1280,
             height: 720,
             fps: 30,


### PR DESCRIPTION
Seems like there is no good match for opentok's rgba32 format, so use i420p as
default. Also in the example ensure video frames size match with the capturer settings.